### PR TITLE
feat: start chat from CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ export ELIA_DIRECTIVE="You are a helpful assistant who talks like a pirate."
 elia
 ```
 
+### Launching Directly into a Conversation
+
+```bash
+elia chat write python code to detect a palindrome
+```
+
 ## Progress updates
 
 ### June 2023

--- a/elia_chat/__main__.py
+++ b/elia_chat/__main__.py
@@ -3,13 +3,16 @@ Elia CLI
 """
 
 import pathlib
+from typing import Tuple
 
 import click
 
-from elia_chat.app import app
+from elia_chat.app import Elia
 from elia_chat.database.create_database import create_database
 from elia_chat.database.import_chatgpt import import_chatgpt_data
 from elia_chat.database.models import sqlite_file_name
+from elia_chat.models import EliaContext
+from elia_chat.widgets.chat_options import DEFAULT_MODEL, MODEL_MAPPING
 
 
 @click.group(invoke_without_command=True)
@@ -18,6 +21,7 @@ def cli(context: click.Context) -> None:
     """
     Elia: A terminal ChatGPT client built with Textual
     """
+    app = Elia(context=None)
     # Run the app if no subcommand is provided
     if context.invoked_subcommand is None:
         # Create the database if it doesn't exist
@@ -55,6 +59,24 @@ def import_file_to_db(file) -> None:
     """
     import_chatgpt_data(file=file)
     click.echo(f"✅  ChatGPT data imported into database {file}")
+
+
+@cli.command()
+@click.argument("message", nargs=-1, type=str, required=True)
+@click.option(
+    "-m",
+    "--model",
+    type=click.Choice(choices=list(MODEL_MAPPING.keys())),
+    default=DEFAULT_MODEL.name,
+    help="The model to use for the chat",
+)
+def chat(message: Tuple[str, ...], model: str) -> None:
+    """
+    Start Elia with a chat message
+    """
+    context = EliaContext(chat_message=" ".join(message), model_name=model)
+    app = Elia(context=context)
+    app.run()
 
 
 if __name__ == "__main__":

--- a/elia_chat/app.py
+++ b/elia_chat/app.py
@@ -1,18 +1,24 @@
 import os
 from pathlib import Path
+from typing import Optional
 
 import openai
 from textual.app import App
 
+from elia_chat.models import EliaContext
 from elia_chat.screens.chat_screen import ChatScreen
 
 
 class Elia(App):
     CSS_PATH = Path(__file__).parent / "elia.scss"
 
-    def __init__(self):
+    def __init__(self, context: Optional[EliaContext] = None) -> None:
+        """
+        Initialize Elia with an optional context
+        """
         super().__init__()
         openai.api_key = os.getenv("OPENAI_API_KEY")
+        self.elia_context = context or EliaContext()
 
     def on_mount(self) -> None:
         self.push_screen(ChatScreen())

--- a/elia_chat/models.py
+++ b/elia_chat/models.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import TypedDict
+from typing import TypedDict, Optional
+
+from elia_chat.widgets.chat_options import GPTModel, MODEL_MAPPING, DEFAULT_MODEL
 
 
 class ChatMessage(TypedDict):
@@ -49,3 +51,20 @@ class ChatData:
         return datetime.fromtimestamp(
             self.messages[-1].get("timestamp", 0) if self.messages else 0
         )
+
+
+@dataclass
+class EliaContext:
+    """
+    Elia Context
+    """
+
+    chat_message: Optional[str] = None
+    model_name: str = DEFAULT_MODEL.name
+
+    @property
+    def gpt_model(self) -> GPTModel:
+        gpt_model = MODEL_MAPPING.get(self.model_name)
+        if gpt_model is None:
+            raise ValueError(f"Unknown model name: {self.model_name}")
+        return gpt_model

--- a/elia_chat/widgets/chat_options.py
+++ b/elia_chat/widgets/chat_options.py
@@ -44,6 +44,7 @@ AVAILABLE_MODELS = [
         css_class="gpt4",
     ),
 ]
+MODEL_MAPPING = {model.name: model for model in AVAILABLE_MODELS}
 
 
 class ModelPanel(Static):


### PR DESCRIPTION
## Summary

This PR adds a new CLI argument, `chat` which immediately launches a new conversation in the app: 

```
elia chat write python code to detect a palindrome
```

When using this new CLI option, the user bypasses the need to select a model and enter their prompt into the input box. Instead a new chat is created automatically and the focus is placed on the input bar for the next message. 

The new CLI argument also accepts a `--model` flag, so you can use `gpt-4`.

## Implementation

The big behavior change here is to introduce a new context object that's passed through to the app. This context object can then be used by any of the app's widgets. The actual work of starting the chat is done here on the `Chat` widget:
```python
async def on_mount(self, _: events.Mount) -> None:
    """
    When the component is mounted, we need to check if there is a new chat to start
    """
    app_context: EliaContext = self.app.elia_context  # type: ignore[attr-defined]
    gpt_model = app_context.gpt_model
    self.chat_data.model_name = gpt_model.name
    chat_input = self.query_one("#chat-input")
    if app_context.chat_message is not None:
        await self.prepare_for_new_chat()
        await self.new_user_message(app_context.chat_message)
        chat_input.focus()
```