### PR TITLE
Update to latest Textual, fix dependencies, add inline mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ The example file below shows the available options, as well as examples of how t
 default_model = "elia-gpt-3.5-turbo"
 # the system prompt on launch
 system_prompt = "You are a helpful assistant who talks like a pirate."
+# change the syntax highlighting theme of code in messages
+# choose from https://pygments.org/styles/
+message_code_theme = "dracula"
 
 # example of adding local llama3 support
 # only the `name` field is required here.

--- a/README.md
+++ b/README.md
@@ -32,10 +32,22 @@ Launch Elia from the command line:
 elia
 ```
 
-Launch directly a new chat from the command line:
+Launch a new chat inline (under your prompt) with `-i`/`--inline`:
 
 ```bash
-elia "What is the Zen of Python?"
+elia -i "What is the Zen of Python?"
+```
+
+Launch a new chat in full-screen mode:
+
+```bash
+elia "Tell me a cool fact about lizards!"
+```
+
+Specify a model via the command line using `-m`/`--model`:
+
+```bash
+elia -m gpt-4o
 ```
 
 ## Running local models
@@ -54,7 +66,7 @@ The example file below shows the available options, as well as examples of how t
 
 ```toml
 # the ID or name of the model that is selected by default on launch
-default_model = "elia-gpt-3.5-turbo"
+default_model = "gpt-4o"
 # the system prompt on launch
 system_prompt = "You are a helpful assistant who talks like a pirate."
 # change the syntax highlighting theme of code in messages

--- a/README.md
+++ b/README.md
@@ -53,14 +53,13 @@ the options window (`ctrl+o`).
 The example file below shows the available options, as well as examples of how to add new models.
 
 ```toml
-# the *ID* for the model that is selected by default on launch
-# to use one of the default builtin OpenAI/anthropic models, prefix
-# the model name with `elia-`.
+# the ID or name of the model that is selected by default on launch
 default_model = "elia-gpt-3.5-turbo"
 # the system prompt on launch
 system_prompt = "You are a helpful assistant who talks like a pirate."
 # change the syntax highlighting theme of code in messages
 # choose from https://pygments.org/styles/
+# defaults to "monokai"
 message_code_theme = "dracula"
 
 # example of adding local llama3 support

--- a/elia_chat/app.py
+++ b/elia_chat/app.py
@@ -28,7 +28,7 @@ class Elia(App[None]):
     CSS_PATH = Path(__file__).parent / "elia.scss"
     BINDINGS = [
         Binding("q", "app.quit", "Quit", show=False),
-        Binding("?", "help", "Help"),
+        Binding("f1,?", "help", "Help"),
     ]
 
     def __init__(self, config: LaunchConfig, startup_prompt: str = ""):

--- a/elia_chat/chats_manager.py
+++ b/elia_chat/chats_manager.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import datetime
 
+from sqlmodel import select
 from textual import log
 
 from elia_chat.database.converters import (
@@ -86,6 +87,15 @@ class ChatsManager:
             await session.commit()
 
         return chat.id
+
+    @staticmethod
+    async def archive_chat(chat_id: int) -> None:
+        async with get_session() as session:
+            statement = select(ChatDao).where(ChatDao.id == chat_id)
+            result = await session.exec(statement)
+            chat_dao = result.one()
+            chat_dao.archived = True
+            await session.commit()
 
     @staticmethod
     async def add_message_to_chat(chat_id: int, message: ChatMessage) -> None:

--- a/elia_chat/config.py
+++ b/elia_chat/config.py
@@ -153,7 +153,7 @@ class LaunchConfig(BaseModel):
             "ELIA_SYSTEM_PROMPT", "You are a helpful assistant named Elia."
         )
     )
-    message_code_theme: str = Field(default="dracula")
+    message_code_theme: str = Field(default="monokai")
     """The default Pygments syntax highlighting theme to be used in chatboxes."""
     models: list[EliaChatModel] = Field(default_factory=list)
     builtin_models: list[EliaChatModel] = Field(

--- a/elia_chat/config.py
+++ b/elia_chat/config.py
@@ -146,7 +146,7 @@ class LaunchConfig(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    default_model: str = Field(default="elia-gpt-3.5-turbo")
+    default_model: str = Field(default="elia-gpt-4o")
     """The ID or name of the default model."""
     system_prompt: str = Field(
         default=os.getenv(

--- a/elia_chat/config.py
+++ b/elia_chat/config.py
@@ -153,6 +153,8 @@ class LaunchConfig(BaseModel):
             "ELIA_SYSTEM_PROMPT", "You are a helpful assistant named Elia."
         )
     )
+    message_code_theme: str = Field(default="dracula")
+    """The default Pygments syntax highlighting theme to be used in chatboxes."""
     models: list[EliaChatModel] = Field(default_factory=list)
     builtin_models: list[EliaChatModel] = Field(
         default_factory=get_builtin_models, init=False

--- a/elia_chat/config.py
+++ b/elia_chat/config.py
@@ -58,7 +58,7 @@ def get_builtin_openai_models() -> list[EliaChatModel]:
         ),
         EliaChatModel(
             id="elia-gpt-4o",
-            name="openai/gpt-4o",
+            name="gpt-4o",
             display_name="GPT-4o",
             provider="OpenAI",
             product="ChatGPT",

--- a/elia_chat/database/models.py
+++ b/elia_chat/database/models.py
@@ -75,6 +75,7 @@ class ChatDao(AsyncAttrs, SQLModel, table=True):
             statement = (
                 select(ChatDao)
                 .join(subquery, subquery.c.chat_id == ChatDao.id)
+                .where(ChatDao.archived == False)
                 .order_by(desc(subquery.c.max_timestamp))
                 .options(selectinload(ChatDao.messages))
             )

--- a/elia_chat/elia.scss
+++ b/elia_chat/elia.scss
@@ -39,7 +39,10 @@ Screen {
 ModalScreen {
   background: black 50%;
   padding: 0;
-
+  &:inline {
+    padding: 0;
+    border: none;
+  }
   & Footer {
     margin: 0 2 1 2;
   }

--- a/elia_chat/elia.scss
+++ b/elia_chat/elia.scss
@@ -30,6 +30,10 @@ Tabs .underline--bar {
 Screen {
   background: $background;
   padding: 0 2 1 2;
+  &:inline {
+    height: 50vh;
+    padding: 0 2;
+  }
 }
 
 ModalScreen {
@@ -75,6 +79,9 @@ Chat {
     height: auto;
     padding: 1 2;
     background: $background;
+    &:inline {
+      padding: 0 2 1 2;
+    }
 
     & #model-static {
       color: $text-muted;
@@ -163,6 +170,11 @@ AppHeader {
   width: 1fr;
   padding: 1 2;
   height: auto;
+
+  &:inline {
+    padding: 0 2 1 2;
+  }
+
   & .app-title {
     color: $text-muted;
   }
@@ -378,10 +390,6 @@ MessageInfo #token-count {
 
 Tabs:focus .underline--bar {
   color: $text 35%;
-}
-
-TokenAnalysis {
-  height: auto;
 }
 
 MessageInfo #inner-container ContentSwitcher {

--- a/elia_chat/elia.scss
+++ b/elia_chat/elia.scss
@@ -31,7 +31,7 @@ Screen {
   background: $background;
   padding: 0 2 1 2;
   &:inline {
-    height: 50vh;
+    height: 80vh;
     padding: 0 2;
   }
 }

--- a/elia_chat/screens/chat_screen.py
+++ b/elia_chat/screens/chat_screen.py
@@ -15,7 +15,7 @@ class ChatScreen(Screen[None]):
     BINDINGS = [
         Binding(
             key="escape",
-            action="focus('prompt')",
+            action="app.focus('prompt')",
             description="Focus prompt",
             key_display="esc",
         ),

--- a/elia_chat/screens/help_screen.py
+++ b/elia_chat/screens/help_screen.py
@@ -8,7 +8,7 @@ from textual.widgets import Footer, Markdown
 class HelpScreen(ModalScreen[None]):
     BINDINGS = [
         Binding("q", "app.quit", "Quit", show=False),
-        Binding("escape,?", "app.pop_screen()", "Close help", key_display="esc"),
+        Binding("escape,f1,?", "app.pop_screen()", "Close help", key_display="esc"),
     ]
 
     HELP_MARKDOWN = """\

--- a/elia_chat/widgets/chat.py
+++ b/elia_chat/widgets/chat.py
@@ -86,13 +86,13 @@ class Chat(Widget):
         chat_data: ChatData
 
     def compose(self) -> ComposeResult:
+        yield AgentIsTyping()
         yield ChatHeader(chat=self.chat_data, model=self.model)
 
         with VerticalScroll(id="chat-container") as vertical_scroll:
             vertical_scroll.can_focus = False
 
         yield ChatPromptInput(id="prompt")
-        yield AgentIsTyping()
 
     async def on_mount(self, _: events.Mount) -> None:
         """

--- a/elia_chat/widgets/chat_list.py
+++ b/elia_chat/widgets/chat_list.py
@@ -57,7 +57,7 @@ class ChatListItem(Option):
 class ChatList(OptionList):
     BINDINGS = [
         Binding(
-            "escape", "screen.focus('home-prompt')", "Focus prompt", key_display="esc"
+            "escape", "app.focus('home-prompt')", "Focus prompt", key_display="esc"
         ),
         Binding("j,down", "cursor_down", "Down", show=False),
         Binding("k,up", "cursor_up", "Up", show=False),

--- a/elia_chat/widgets/chat_list.py
+++ b/elia_chat/widgets/chat_list.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime
 from dataclasses import dataclass
+from typing import cast
 
 import humanize
 from rich.console import RenderResult, Console, ConsoleOptions
@@ -59,6 +60,7 @@ class ChatList(OptionList):
         Binding(
             "escape", "app.focus('home-prompt')", "Focus prompt", key_display="esc"
         ),
+        Binding("a", "archive_chat", "Archive chat", key_display="a"),
         Binding("j,down", "cursor_down", "Down", show=False),
         Binding("k,up", "cursor_up", "Up", show=False),
         Binding("l,right,enter", "select", "Select", show=False),
@@ -110,7 +112,7 @@ class ChatList(OptionList):
         old_highlighted = self.highlighted
         self.clear_options()
         self.add_options(self.options)
-        self.border_title = f"History ({len(self.options)})"
+        self.border_title = self.get_border_title()
         if new_highlighted > -1:
             self.highlighted = new_highlighted
         else:
@@ -123,6 +125,24 @@ class ChatList(OptionList):
     async def load_chats(self) -> list[ChatData]:
         all_chats = await ChatsManager.all_chats()
         return all_chats
+
+    async def action_archive_chat(self) -> None:
+        if self.highlighted is None:
+            return
+
+        item = cast(ChatListItem, self.get_option_at_index(self.highlighted))
+        self.options.pop(self.highlighted)
+        self.remove_option_at_index(self.highlighted)
+
+        chat_id = item.chat.id
+        await ChatsManager.archive_chat(chat_id)
+
+        self.border_title = self.get_border_title()
+        self.refresh()
+        self.app.notify(f"Chat [b]{chat_id!r}[/] archived")
+
+    def get_border_title(self) -> str:
+        return f"History ({len(self.options)})"
 
     def create_chat(self, chat_data: ChatData) -> None:
         new_chat_list_item = ChatListItem(chat_data, self.app.launch_config)

--- a/elia_chat/widgets/chatbox.py
+++ b/elia_chat/widgets/chatbox.py
@@ -98,7 +98,9 @@ class SelectionTextArea(TextArea):
             message = f"Copied message ({len(text_to_copy)} characters)."
             self.notify(message, title="Message copied")
 
-        self.app.copy_to_clipboard(text_to_copy)
+        import pyperclip
+
+        pyperclip.copy(text_to_copy)
         self.visual_mode = False
 
     def action_next_code_block(self) -> None:
@@ -204,7 +206,9 @@ class Chatbox(Widget, can_focus=True):
         if not self.selection_mode:
             text_to_copy = self.message.message.get("content")
             if isinstance(text_to_copy, str):
-                self.app.copy_to_clipboard(text_to_copy)
+                import pyperclip
+
+                pyperclip.copy(text_to_copy)
                 message = f"Copied message ({len(text_to_copy)} characters)."
                 self.notify(message, title="Message copied")
             else:

--- a/elia_chat/widgets/chatbox.py
+++ b/elia_chat/widgets/chatbox.py
@@ -18,6 +18,7 @@ from textual.document._syntax_aware_document import SyntaxAwareDocumentError
 
 from elia_chat.config import EliaChatModel
 from elia_chat.models import ChatMessage
+from elia_chat.config import launch_config
 
 
 class SelectionTextArea(TextArea):
@@ -260,7 +261,9 @@ class Chatbox(Widget, can_focus=True):
         content = self.message.message.get("content")
         if not isinstance(content, str):
             content = ""
-        return Markdown(content, code_theme="dracula")
+
+        config = launch_config.get()
+        return Markdown(content, code_theme=config.message_code_theme)
 
     def render(self) -> RenderableType:
         if self.selection_mode:

--- a/elia_chat/widgets/chatbox.py
+++ b/elia_chat/widgets/chatbox.py
@@ -260,7 +260,7 @@ class Chatbox(Widget, can_focus=True):
         content = self.message.message.get("content")
         if not isinstance(content, str):
             content = ""
-        return Markdown(content)
+        return Markdown(content, code_theme="dracula")
 
     def render(self) -> RenderableType:
         if self.selection_mode:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "elia_chat"
-version = "1.5.0"
+version = "1.6.0"
 description = "A powerful terminal user interface for interacting with large language models."
 authors = [
     { name = "Darren Burns", email = "darrenb900@gmail.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,15 +6,14 @@ authors = [
     { name = "Darren Burns", email = "darrenb900@gmail.com" }
 ]
 dependencies = [
-    "textual[syntax]==0.58.1",
+    "textual[syntax]==0.62.0",
     "sqlmodel>=0.0.9",
     "humanize>=4.6.0",
     "click>=8.1.6",
     "xdg-base-dirs>=6.0.1",
-    "pydantic-settings>=2.2.1",
     "aiosqlite>=0.20.0",
     "click-default-group>=1.2.4",
-    "litellm>=1.35.38",
+    "litellm==1.35.38",
     "greenlet>=3.0.3",
     "google-generativeai>=0.5.3",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "litellm==1.35.38",
     "greenlet>=3.0.3",
     "google-generativeai>=0.5.3",
+    "pyperclip>=1.8.2",
 ]
 readme = "README.md"
 requires-python = ">= 3.11"

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -167,6 +167,8 @@ pygments==2.17.2
 pyinstrument==4.6.2
 pyparsing==3.1.2
     # via httplib2
+pyperclip==1.8.2
+    # via elia-chat
 python-dotenv==1.0.1
     # via litellm
 pyyaml==6.0.1

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -76,7 +76,6 @@ googleapis-common-protos==1.63.0
     # via grpcio-status
 greenlet==3.0.3
     # via elia-chat
-    # via sqlalchemy
 grpcio==1.63.0
     # via google-api-core
     # via grpcio-status
@@ -160,12 +159,9 @@ pyasn1-modules==0.4.0
 pydantic==2.6.1
     # via google-generativeai
     # via openai
-    # via pydantic-settings
     # via sqlmodel
 pydantic-core==2.16.2
     # via pydantic
-pydantic-settings==2.2.1
-    # via elia-chat
 pygments==2.17.2
     # via rich
 pyinstrument==4.6.2
@@ -173,7 +169,6 @@ pyparsing==3.1.2
     # via httplib2
 python-dotenv==1.0.1
     # via litellm
-    # via pydantic-settings
 pyyaml==6.0.1
     # via huggingface-hub
     # via pre-commit
@@ -198,7 +193,7 @@ sqlalchemy==2.0.25
     # via sqlmodel
 sqlmodel==0.0.14
     # via elia-chat
-textual==0.58.1
+textual==0.62.0
     # via elia-chat
     # via textual-dev
 textual-dev==1.4.0

--- a/requirements.lock
+++ b/requirements.lock
@@ -140,6 +140,8 @@ pygments==2.17.2
     # via rich
 pyparsing==3.1.2
     # via httplib2
+pyperclip==1.8.2
+    # via elia-chat
 python-dotenv==1.0.1
     # via litellm
 pyyaml==6.0.1

--- a/requirements.lock
+++ b/requirements.lock
@@ -67,7 +67,6 @@ googleapis-common-protos==1.63.0
     # via grpcio-status
 greenlet==3.0.3
     # via elia-chat
-    # via sqlalchemy
 grpcio==1.63.0
     # via google-api-core
     # via grpcio-status
@@ -134,19 +133,15 @@ pyasn1-modules==0.4.0
 pydantic==2.6.1
     # via google-generativeai
     # via openai
-    # via pydantic-settings
     # via sqlmodel
 pydantic-core==2.16.2
     # via pydantic
-pydantic-settings==2.2.1
-    # via elia-chat
 pygments==2.17.2
     # via rich
 pyparsing==3.1.2
     # via httplib2
 python-dotenv==1.0.1
     # via litellm
-    # via pydantic-settings
 pyyaml==6.0.1
     # via huggingface-hub
 regex==2023.12.25
@@ -168,7 +163,7 @@ sqlalchemy==2.0.25
     # via sqlmodel
 sqlmodel==0.0.14
     # via elia-chat
-textual==0.58.1
+textual==0.62.0
     # via elia-chat
 tiktoken==0.5.2
     # via litellm


### PR DESCRIPTION
- Added ability to archive chats by pressing `a` when a chat is highlighted in the chat list.
- Changes the default model from `gpt-3.5-turbo` to `gpt-4o`.
- Adds support for "inline" mode, which allows you to chat with Elia without going fullscreen. The conversation will appear under your prompt in your terminal. This is not supported on Windows.
- Copying text to clipboard should work in more environments (switched to use Pyperclip)
- Added config option to choose syntax highlighting theme for code in messages - any Pygments theme is supported.
- Updates to the latest version of Textual.
