### PR TITLE
Adding basic vim move keys (j, k, l, h and V) for selection mode

### DIFF
--- a/elia_chat/widgets/chat.py
+++ b/elia_chat/widgets/chat.py
@@ -4,8 +4,7 @@ import datetime
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
-from elia_chat import constants
-from textual import log, on, work, events
+from textual import events, log, on, work
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import VerticalScroll
@@ -14,21 +13,20 @@ from textual.message import Message
 from textual.reactive import reactive
 from textual.widget import Widget
 
+from elia_chat import constants
 from elia_chat.chats_manager import ChatsManager
 from elia_chat.models import ChatData, ChatMessage
 from elia_chat.screens.chat_details import ChatDetails
 from elia_chat.widgets.agent_is_typing import AgentIsTyping
 from elia_chat.widgets.chat_header import ChatHeader, TitleStatic
-from elia_chat.widgets.prompt_input import PromptInput
 from elia_chat.widgets.chatbox import Chatbox
-
+from elia_chat.widgets.prompt_input import PromptInput
 
 if TYPE_CHECKING:
+    from litellm.types.completion import (ChatCompletionAssistantMessageParam,
+                                          ChatCompletionUserMessageParam)
+
     from elia_chat.app import Elia
-    from litellm.types.completion import (
-        ChatCompletionUserMessageParam,
-        ChatCompletionAssistantMessageParam,
-    )
 
 
 class ChatPromptInput(PromptInput):

--- a/elia_chat/widgets/chatbox.py
+++ b/elia_chat/widgets/chatbox.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import bisect
 from dataclasses import dataclass
 
@@ -8,17 +9,17 @@ from rich.syntax import Syntax
 from textual import on
 from textual.binding import Binding
 from textual.css.query import NoMatches
+from textual.document._syntax_aware_document import SyntaxAwareDocumentError
 from textual.geometry import Size
 from textual.message import Message
 from textual.reactive import reactive
 from textual.widget import Widget
 from textual.widgets import TextArea
 from textual.widgets.text_area import Selection
-from textual.document._syntax_aware_document import SyntaxAwareDocumentError
 
-from elia_chat.config import EliaChatModel
+from elia_chat.config import EliaChatModel, launch_config
 from elia_chat.models import ChatMessage
-from elia_chat.config import launch_config
+from elia_chat.widgets.vim_mode import vim_modize
 
 
 class SelectionTextArea(TextArea):
@@ -31,26 +32,39 @@ class SelectionTextArea(TextArea):
 
         enabled: bool
 
-    BINDINGS = [
-        Binding(
-            "escape",
-            "leave_selection_mode",
-            description="Exit selection mode",
-            key_display="esc",
-        ),
-        Binding(
-            "v",
-            "toggle_visual_mode",
-            description="Toggle visual select",
-            key_display="v",
-        ),
-        Binding(
-            "y,c", "copy_to_clipboard", description="Copy selection", key_display="y"
-        ),
-        Binding("u", "next_code_block", description="Next code block", key_display="u"),
-    ]
+    BINDINGS = vim_modize(
+        [
+            Binding(
+                "escape",
+                "leave_selection_mode",
+                description="Exit selection mode",
+                key_display="esc",
+            ),
+            Binding(
+                "v",
+                "toggle_visual_mode",
+                description="Toggle visual select",
+                key_display="v",
+            ),
+            Binding(
+                "y,c",
+                "copy_to_clipboard",
+                description="Copy selection",
+                key_display="y",
+            ),
+            Binding(
+                "u", "next_code_block", description="Next code block", key_display="u"
+            ),
+        ],
+        selection=True,
+        movement=True,
+    )
 
     visual_mode = reactive(False, init=False)
+
+    def action_select_line(self) -> None:
+        self.visual_mode = True
+        super().action_select_line()
 
     def action_toggle_visual_mode(self) -> None:
         self.visual_mode = not self.visual_mode

--- a/elia_chat/widgets/prompt_input.py
+++ b/elia_chat/widgets/prompt_input.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
+
 from textual import events, on
 from textual.binding import Binding
-from textual.widgets import TextArea
 from textual.message import Message
+from textual.widgets import TextArea
 
 
 class PromptInput(TextArea):

--- a/elia_chat/widgets/vim_mode.py
+++ b/elia_chat/widgets/vim_mode.py
@@ -1,0 +1,54 @@
+from textual.binding import Binding
+
+MOVEMENT_BINDINGS = [
+    Binding(
+        "h",
+        "cursor_left",
+        description="Cursor left",
+        key_display="V",
+        show=False,
+    ),
+    Binding(
+        "l",
+        "cursor_right",
+        description="Cursor right",
+        key_display="V",
+        show=False,
+    ),
+    Binding(
+        "k",
+        "cursor_up",
+        description="Cursor up",
+        key_display="V",
+        show=False,
+    ),
+    Binding(
+        "j",
+        "cursor_down",
+        description="Cursor down",
+        key_display="V",
+        show=False,
+    ),
+]
+
+SELECTION_BINDINGS = [
+    Binding(
+        "V",
+        "select_line",
+        description="Select current line ",
+        key_display="V",
+        show=False,
+    ),
+]
+
+
+def vim_modize(
+    bindings: list[Binding], movement=True, selection=False
+) -> list[Binding]:
+    if movement:
+        bindings.extend(MOVEMENT_BINDINGS)
+
+    if selection:
+        bindings.extend(SELECTION_BINDINGS)
+
+    return bindings


### PR DESCRIPTION
Adding basic vim moves on selection mode: (h, l; j, k, and V)

Example: 

[elia-vim-movements_ 2024-06-13 09-10.webm](https://github.com/darrenburns/elia/assets/1083967/028f34af-400f-4c37-9a9e-25d9402e5d96)
