### PR TITLE
WIP: Allow to export chats

### DIFF
--- a/elia_chat/database/export_chatgpt.py
+++ b/elia_chat/database/export_chatgpt.py
@@ -1,0 +1,46 @@
+import json
+from pathlib import Path
+from typing import Optional
+
+from rich.console import Console
+from rich.live import Live
+from rich.text import Text
+
+from elia_chat.database.models import ChatDao
+
+
+async def export_chatgpt_data(chat: str, file: Optional[Path]) -> Path:
+    console = Console()
+
+    def output_progress(exported_count: int, message_count: int) -> Text:
+        style = "green" if exported_count == message_count else "yellow"
+        return Text.from_markup(
+            f"Exported [b]{exported_count}[/] of [b]{message_count}[/] messages.",
+            style=style,
+        )
+
+    chat_id: int = 0
+    try:
+        chat_id = int(chat)
+    except ValueError:
+        all_chats = await ChatDao.all()
+        chat_by_name = list(filter(lambda c: c.title == chat, all_chats))[0]
+        chat_id = chat_by_name.id
+    chat_dao = await ChatDao.from_id(chat_id)
+    messages = chat_dao.messages
+    message_count = 0
+    export = {"title": chat_dao.title, "id": chat_dao.id, "messages": []}
+    with Live(output_progress(0, len(messages))) as live:
+        for message in messages:
+            export["messages"].append(message.as_dict())
+            message_count = message_count + 1
+            live.update(output_progress(message_count, len(messages)))
+
+    console.print(json.dumps(export, indent=2))
+    if file is None:
+        file = Path(f"{chat_dao.title}_export.json")
+    with open(file, "w+", encoding="utf-8") as f:
+        json.dump(export, f, indent=2)
+    console.print("[green]Exported chat to json.")
+
+    return file

--- a/elia_chat/database/models.py
+++ b/elia_chat/database/models.py
@@ -1,7 +1,7 @@
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
-from sqlalchemy import Column, DateTime, func, JSON, desc
+from sqlalchemy import JSON, Column, DateTime, desc, func
 from sqlalchemy.ext.asyncio import AsyncAttrs
 from sqlalchemy.orm import selectinload
 from sqlmodel import Field, Relationship, SQLModel, select
@@ -46,6 +46,17 @@ class MessageDao(AsyncAttrs, SQLModel, table=True):
     """
     model: str | None
     """The model that wrote this response. (Could switch models mid-chat, possibly)"""
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "timestamp": self.timestamp.isoformat(),
+            "chat_id": self.chat_id,
+            "role": self.role,
+            "content": self.content,
+            "meta": self.meta,
+            "model": self.model,
+        }
 
 
 class ChatDao(AsyncAttrs, SQLModel, table=True):


### PR DESCRIPTION
**Still WIP**

I want to be able to export chats for 2 main reasons:

* In case of working specifically on a project, be able to track the history of the conversation for the other committers  (e.g.: in the repository). 
I think this might be useful for other people to understand how you get to a specific solution.

I did json at first, but I guess it might be more convenient to use Markdown to make it more readable straight from the browser.

* To be able to import (inter-exchange in general) chats from **elia** in other tools (such as ChatGPT neovim's plugin). 

Sometimes I like to work inside the editor and sometimes it more comfortable to use just the terminal. I think it might be nice to be able to use the same conversation.
An alternative to this might be to have some hooks integrating other tools (such a a 'remote' mode for elia)

