### PR TITLE
Configs: add openai limited access o1 models; add xAI grok-beta

### DIFF
--- a/elia_chat/config.py
+++ b/elia_chat/config.py
@@ -32,13 +32,15 @@ class EliaChatModel(BaseModel):
     """A description of the model which may appear inside the Elia UI."""
     product: str | None = Field(default=None)
     """For example `ChatGPT`, `Claude`, `Gemini`, etc."""
-    temperature: float = Field(default=1.0)
+    temperature: float | None = Field(default=1.0)
     """The temperature to use. Low temperature means the same prompt is likely
     to produce similar results. High temperature means a flatter distribution
     when predicting the next token, and so the next token will be more random.
     Setting a very high temperature will likely produce junk output."""
     max_retries: int = Field(default=0)
-    """The number of times to retry a request after it fails before giving up."""
+    """Whether a model is limits access to special groups of users and should
+    not be shown to all users. Users who know/want these models can opt-in."""
+    is_limited_access: bool = Field(default=False)
 
     @property
     def lookup_key(self) -> str:
@@ -73,6 +75,26 @@ def get_builtin_openai_models() -> list[EliaChatModel]:
             product="ChatGPT",
             description="Previous high-intelligence model.",
             temperature=0.7,
+        ),
+        EliaChatModel(
+            id="elia-o1-mini",
+            name="o1-mini",
+            display_name="o1-mini",
+            provider="OpenAI",
+            product="ChatGPT",
+            description="Faster and cheaper version of o1, adept at coding, math, and science tasks where extensive general knowledge isn't required.",
+            temperature=None,  # o1 models do not support temperature param
+            is_limited_access=True,
+        ),
+        EliaChatModel(
+            id="elia-o1-preview",
+            name="o1-preview",
+            display_name="o1-preview",
+            provider="OpenAI",
+            product="ChatGPT",
+            description="Early preview of o1 model, designed to reason about hard problems using broad general knowledge about the world.",
+            temperature=None,  # o1 models do not support temperature param
+            is_limited_access=True,
         ),
     ]
 

--- a/elia_chat/config.py
+++ b/elia_chat/config.py
@@ -38,9 +38,10 @@ class EliaChatModel(BaseModel):
     when predicting the next token, and so the next token will be more random.
     Setting a very high temperature will likely produce junk output."""
     max_retries: int = Field(default=0)
+    """The number of times to retry a request after it fails before giving up."""
+    is_limited_access: bool = Field(default=False)
     """Whether a model is limits access to special groups of users and should
     not be shown to all users. Users who know/want these models can opt-in."""
-    is_limited_access: bool = Field(default=False)
 
     @property
     def lookup_key(self) -> str:

--- a/elia_chat/config.py
+++ b/elia_chat/config.py
@@ -40,8 +40,8 @@ class EliaChatModel(BaseModel):
     max_retries: int = Field(default=0)
     """The number of times to retry a request after it fails before giving up."""
     is_limited_access: bool = Field(default=False)
-    """Whether a model is limits access to special groups of users and should
-    not be shown to all users. Users who know/want these models can opt-in."""
+    """Whether a model/api limits access to special groups of users and should
+    be noted as such to interested users. Users who know/want these models can opt-in."""
 
     @property
     def lookup_key(self) -> str:

--- a/elia_chat/widgets/chat_options.py
+++ b/elia_chat/widgets/chat_options.py
@@ -74,6 +74,9 @@ class OptionsModal(ModalScreen[RuntimeConfig]):
                     if provider:
                         label += f" [i]by[/] {provider}"
 
+                    if model.is_limited_access:
+                        label += f" [dim](Limited Access – check with provider for your eligibility)[/]"
+
                     ids_defined = selected_model.id and model.id
                     same_id = ids_defined and selected_model.id == model.id
                     same_name = selected_model.name == model.name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "elia_chat"
-version = "1.10.0"
+version = "1.11.0"
 description = "A powerful terminal user interface for interacting with large language models."
 authors = [
     { name = "Darren Burns", email = "darrenb900@gmail.com" }


### PR DESCRIPTION
# Add OpenAI o1 models

<img width="909" alt="image" src="https://github.com/user-attachments/assets/8a8c3472-e78d-484a-a040-e863d9c64ca9">

So whoever with API access **can** use it.

- add `o1-{mini,preview}` models to config

- make `temperature` param allow `None`, because the stack of `litellm`/`openai`/`o1` does not accept temperature param

![image](https://github.com/user-attachments/assets/835d0b61-0ee4-4c6c-b993-c1832cedeea4)

- introduce `is_limited_access` flag (default False, on for these two models)

what happens if you don't have access but you select the models anyway

![image](https://github.com/user-attachments/assets/690a0ca4-11d9-4a60-a677-8e42f983d278)
